### PR TITLE
Fix to pdf book build error

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: remove binder image line from edna example
+        run: |
+          sed -i '/Binder/d' datasets/dataset-edna/README.md
+
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: '4.1.1'

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: remove binder image line from edna example
-        run: |
-          sed -i'' -e '/Binder/d' datasets/dataset-edna/README.md
-
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: '4.1.1'
@@ -38,13 +34,25 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Render Book
+      - name: Render Html Book
         run: Rscript -e '
           setwd("bio-data-guide/"); 
           options(knitr.duplicate.label = "allow");
-          bookdown::render_book("index.Rmd");
-          bookdown::render_book("index.Rmd", "bookdown::pdf_book");
+          bookdown::render_book("index.Rmd");'
+          
+      - name: Render epub book
+        run: Rscript -e '
+          options(knitr.duplicate.label = "allow");
           bookdown::render_book("index.Rmd", "bookdown::epub_book")'
+
+      - name: remove binder image line from edna example for pdf
+        run: |
+          sed -i'' -e '/Binder/d' datasets/dataset-edna/README.md
+
+      - name: Render pdf book
+        run: Rscript -e '
+          options(knitr.duplicate.label = "allow");
+          bookdown::render_book("index.Rmd", "bookdown::pdf_book")'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -42,6 +42,7 @@ jobs:
           
       - name: Render epub book
         run: Rscript -e '
+          setwd("bio-data-guide/"); 
           options(knitr.duplicate.label = "allow");
           bookdown::render_book("index.Rmd", "bookdown::epub_book")'
 
@@ -51,6 +52,7 @@ jobs:
 
       - name: Render pdf book
         run: Rscript -e '
+          setwd("bio-data-guide/"); 
           options(knitr.duplicate.label = "allow");
           bookdown::render_book("index.Rmd", "bookdown::pdf_book")'
 

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: remove binder image line from edna example
         run: |
-          sed -i '/Binder/d' datasets/dataset-edna/README.md
+          sed -i'' -e '/Binder/d' datasets/dataset-edna/README.md
 
       - uses: r-lib/actions/setup-r@v1
         with:


### PR DESCRIPTION
To fix the pdf building error, we now manually remove that line from the README.md then build the pdf. 

Fortunately, this issue doesn't occur when we build the html or epub version, so I split all the different book builds out into different steps. This will make it easier to debug later too.

closes #117 