### PR TITLE
Create dataset review issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset_review.yaml
+++ b/.github/ISSUE_TEMPLATE/dataset_review.yaml
@@ -1,0 +1,53 @@
+name: Dataset Review Request
+description: Request Reviews & Comments on Your Dataset
+title: "[datset]: "
+labels: ["data help"]
+assignees:
+  - abenson
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request comments from the community on your DwC-formmatting attempt.
+        Do this when you are *almost* ready to submit your DwC .csv files.
+  - type: input
+    id: dataset_name
+    attributes:
+      label: Datset Name
+      description: A short name used to refer to your dataset.
+      placeholder: e.g. fl_keys_mbon_zooplankton_2018
+    validations:
+      required: true
+  - type: input
+    id: link_to_dwc_files
+    attributes:
+      label: Link to DwC Data Files
+      description: A publicly-accessible link to your DwC files.
+      placeholder: e.g. https://drive.google.com/drive/folders/1FcyUnXjqIeh2XF7uhuuvKL8eYGSaJVvZ
+    validations:
+      required: false
+  - type: input
+    id: code_link
+    attributes:
+      label: Scripts Link
+      description: A link to any code used to work with this data.
+      placeholder: e.g. fl_keys_mbon_zooplankton_2018
+    validations:
+      required: false
+  - type: input
+    id: link_to_raw_files
+    attributes:
+      label: Link to "raw" Data Files
+      description: A link to publicly-accessible "raw" data files before conversion to DwC.
+      placeholder: e.g. https://drive.google.com/drive/folders/1FcyUnXjqIeh2XF7uhuuvKL8eYGSaJVvZ
+    validations:
+      required: false
+  - type: textarea
+    id: descrip
+    attributes:
+      label: Describe your dataset and any specific requests.
+      description: Describe your dataset and any specific requests.
+      placeholder: I did.. and want help with..
+      value: "I tried but DwC is hard!"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/dataset_review.yaml
+++ b/.github/ISSUE_TEMPLATE/dataset_review.yaml
@@ -1,15 +1,15 @@
 name: Dataset Review Request
 description: Request Reviews & Comments on Your Dataset
-title: "[datset]: "
+title: "[dataset]: "
 labels: ["data help"]
 assignees:
-  - abenson
+  - albenson-usgs
+  - 7yl4r
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request comments from the community on your DwC-formmatting attempt.
-        Do this when you are *almost* ready to submit your DwC .csv files.
+        Use this form to solicit feedback on your work aligning data to Darwin Core.
   - type: input
     id: dataset_name
     attributes:


### PR DESCRIPTION
We should encourage data managers to open issues here instead of emailing Abby about everything. Creating some issue templates might help make that seem more approachable. This PR creates a template for people wanting a second pair of eyes on their DwC alignment efforts.

You can test drive how this works on my fork: https://github.com/7yl4r/bio_data_guide/issues

Thanks to @sebastiandig for being a guinea pig and inspiring this idea.

---------------------------------

This connects in with our ongoing "dataset management protocol" discussion, @MathewBiddle. Hopefully this insn't entirely in the wrong direction.

---------------------------------

Additional thoughts:

should we have separate forms for:
* completely raw data and I don't know how to start
* take a look at my columns and confirm I have the right idea
* final check before adding to IPT
