### PR TITLE
encourage description in "raw" link input

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset_description.yaml
+++ b/.github/ISSUE_TEMPLATE/dataset_description.yaml
@@ -37,8 +37,8 @@ body:
   - type: input
     id: link_to_raw_files
     attributes:
-      label: Link to "raw" Data Files.
-      description: A link to publicly-accessible "raw" data files before conversion to DwC.
-      placeholder: e.g. https://drive.google.com/drive/folders/1FcyUnXjqIeh2XF7uhuuvKL8eYGSaJVvZ
+      label: Info about "raw" Data Files.
+      description: Description (and|or) link to the "raw" data files. 
+      placeholder: The "raw" data is in one big really big excel file with no headers; the raw data can be downloaded from the following link: https://drive.google.com/drive/folders/1FcyUnXjqIeh2XF7uhuuvKL8eYGSaJVvZ
     validations:
       required: false


### PR DESCRIPTION
Many of the dataset issues opened did not include a link to the raw data and the input was left blank.
I adjusted verbiage to encourage users to at least describe the raw data.
It is useful for us to know about where users are starting on their dwc-alignment journey.