### PR TITLE
#288: edit bare links `https://...` in *.qmd; use here() once for paths 

### DIFF
--- a/datasets/atn_satellite_telemetry/atn_satellite_telemetry_netCDF2DwC.qmd
+++ b/datasets/atn_satellite_telemetry/atn_satellite_telemetry_netCDF2DwC.qmd
@@ -40,17 +40,13 @@ See <https://www.ncei.noaa.gov/archive/accession/0282699>
 ```{r}
 # paths ----
 
-url_base <- "https://www.ncei.noaa.gov/data/oceans/archive"
-
+url_base    <- "https://www.ncei.noaa.gov/data/oceans/archive"
 url_package <- "/arc0217/0282699/1.1/data/0-data/"
+url_file    <- "atn_45866_great-white-shark_trajectory_20090923-20091123.nc"
+dir_data    <- here("datasets/atn_satellite_telemetry/data")
 
-url_file <- "atn_45866_great-white-shark_trajectory_20090923-20091123.nc"
-
-url_nc <- paste0(url_base,url_package,url_file)
-
-dir_data <- "datasets/atn_satellite_telemetry/data"
-
-file_nc <- here(file.path(dir_data, "src", basename(url_nc)))
+url_nc  <- paste0(url_base, url_package, url_file)
+file_nc <- file.path(dir_data, "src", url_file)
 
 # stopifnot(dir.exists(dir_data))
 
@@ -370,7 +366,7 @@ names(occurrencedf_dec)
 ```{r}
 tag_id <- metadata %>% dplyr::filter(variable == "NC_GLOBAL" & name == "ptt_id")
 
-occurrencedf_dec_csv <- here(glue::glue("{dir_data}/dwc/atn_{tag_id$value}_occurrence.csv"))
+occurrencedf_dec_csv <- glue::glue("{dir_data}/dwc/atn_{tag_id$value}_occurrence.csv")
 
 write.csv(occurrencedf_dec, file=occurrencedf_dec_csv, row.names=FALSE, fileEncoding="UTF-8", quote=TRUE, na="")
 ```
@@ -458,7 +454,7 @@ str(emofdf)
 ```{r}
 tag_id <- metadata %>% dplyr::filter(variable == "NC_GLOBAL") %>% dplyr::filter(name == "ptt_id")
 
-emof_csv <- here(glue::glue("{dir_data}/dwc/atn_{tag_id$value}_emof.csv"))
+emof_csv <- glue::glue("{dir_data}/dwc/atn_{tag_id$value}_emof.csv")
 
 write.csv(emofdf, file=emof_csv, row.names=FALSE, fileEncoding="UTF-8", quote=TRUE, na="")
 ```

--- a/lib/pre-render.R
+++ b/lib/pre-render.R
@@ -21,7 +21,8 @@ readLines(doc_md) |>
   str_replace(img_url, glue("/{img_svg}")) |>
   writeLines(doc_qmd)
 
-# update bare links {x} (like http:// or https://) in all *.qmd files with angle tags <{x}>, 
+# NEW: skip updating bare links in *.qmd files and simply wrap bare links with carrots in qmd source
+# OLD: update bare links {x} (like http:// or https://) in all *.qmd files with angle tags <{x}>, 
 #   except if already surrounded by a markdown link, ie [.*]({x}) or <{x}>, or in an R chunk
 # The regex pattern (courtesy of claude.ai):
 # - `(?<!\\]\\()` - Negative lookbehind to avoid URLs in markdown links
@@ -33,10 +34,10 @@ readLines(doc_md) |>
 # pattern <- "(?<!\\]\\()(?<!<)(https?://[^\\s)]+)(?!>)(?![^`]*`(?:[^`]*`[^`]*`)*[^`]*$)(?!```[\\s\\S]*?```*$)"
 # qmd_files <- list.files(".", pattern = "\\.qmd$", recursive = T, full.names = T)
 # for (q in qmd_files) {
-#   readLines(q, warn = FALSE) |> 
-#     paste(collapse = "\n") |> 
+#   readLines(q, warn = FALSE) |>
+#     paste(collapse = "\n") |>
 #     str_replace_all(
 #       pattern,
-#       "<\\1>") |> 
+#       "<\\1>") |>
 #     writeLines(q)
 # }


### PR DESCRIPTION
Hi @MathewBiddle,

Here are super minor (skippable even) tweaks wrt #288:

- Better to edit bare links `https://...` in *.qmd directly with `<>`(i.e., `<https://...>`) rather than rely on old regex in [‎lib/pre-render.R](https://github.com/bbest/bio_data_guide/commit/78ae9f28e30c2d99ce2a96da2cd3efed59de4328#diff-9601a04f74dd7a2541cbef95f3dfbb0eca4227bd59f86bd6b703c05f8f20d360).

- Use of `here()` only needed once with `dir_data <- here(datasets/...)`, not later when path `dir_data` used as prefix `glue("{dir_data}/...")` in [datasets/atn_satellite_telemetry/atn_satellite_telemetry_netCDF2DwC.qmd](https://github.com/bbest/bio_data_guide/commit/78ae9f28e30c2d99ce2a96da2cd3efed59de4328#diff-8bd3311e348182525b2c46e98afddf39acae0f2dc24283748239031bc426b824L373)